### PR TITLE
Concurrent sessions do not produce the expected number of profiling reports

### DIFF
--- a/src/Tests/NanoProfiler.Tests/ConcurrencyTest.cs
+++ b/src/Tests/NanoProfiler.Tests/ConcurrencyTest.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EF.Diagnostics.Profiling.Storages;
+using EF.Diagnostics.Profiling.Timings;
+using NUnit.Framework;
+
+namespace EF.Diagnostics.Profiling.Tests
+{
+    /// <summary>
+    ///     Test concurrent profiling sessions using threads and tasks.
+    /// </summary>
+    [TestFixture]
+    public class ConcurrencyTest
+    {
+        [Test]
+        [Repeat(100)]
+        public void NanoProfilerWrapper_WritesReportWhenExitingRootSpan_SaveSessionCallbackAndTasks()
+        {
+            var reports = new ConcurrentBag<string>();
+            ProfilingSession.CircularBuffer = new CircularBuffer<ITimingSession>(200);
+            ProfilingSession.ProfilingStorage = new NanoProfilerStorageInMemory(session => { reports.Add(GetReport(session)); });
+
+            const int count = 10;
+            List<Task<string>> tasks = Enumerable.Range(1, count)
+                .Select(i => Task.Run(DoWork))
+                .ToList();
+
+            Task.WhenAll(tasks).Wait();
+
+            // Due to running two tasks inside each thread, the call context seems a bit arbitrary
+            // so the number of reports vary depending on whether it consider child1.1 and child1.2
+            // spans a child of the DoWork span or not.
+            Assert.AreEqual(reports.Count, count);
+            foreach (string report in reports)
+                Assert.True(report.Contains("root = "), "report.Contains('root = ')");
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void NanoProfilerWrapper_WritesReportWhenExitingRootSpan_WithNoOpStorageAndTasks()
+        {
+            ProfilingSession.CircularBuffer = new CircularBuffer<ITimingSession>(200);
+            ProfilingSession.ProfilingStorage = new NoOperationProfilingStorage();
+
+            const int count = 10;
+            List<Task<string>> tasks = Enumerable.Range(1, count)
+                .Select(i => Task.Run(DoWork))
+                .ToList();
+
+            List<string> reports = Task.WhenAll(tasks).Result.ToList();
+
+            // Due to running two tasks inside each thread, the call context seems a bit arbitrary
+            // so the number of reports vary depending on whether it consider child1.1 and child1.2
+            // spans a child of the DoWork span or not.
+            Assert.AreEqual(reports.Count, count);
+            foreach (string report in reports)
+                Assert.True(report.Contains("root = "), "report.Contains('root = ')");
+        }
+
+        [Test]
+        [Repeat(100)]
+        public void NanoProfilerWrapper_WritesReportWhenExitingRootSpan_WithSaveSessionCallbackAndThreads()
+        {
+            var reports = new ConcurrentBag<string>();
+            ProfilingSession.CircularBuffer = new CircularBuffer<ITimingSession>(200);
+            ProfilingSession.ProfilingStorage = new NanoProfilerStorageInMemory(session => { reports.Add(GetReport(session)); });
+
+            const int threadCount = 10;
+            List<Thread> threads = Enumerable.Range(1, threadCount)
+                .Select(i => new Thread(() =>
+                {
+                    DoWork()
+                        .Wait();
+                }))
+                .ToList();
+
+            threads.ForEach(t => t.Start());
+            threads.ForEach(t => t.Join());
+
+            // Due to running two tasks inside each thread, the call context seems a bit arbitrary
+            // so the number of reports vary depending on whether it consider child1.1 and child1.2
+            // spans a child of the DoWork span or not.
+            Assert.GreaterOrEqual(reports.Count, threadCount);
+            foreach (string report in reports)
+                Assert.True(report.Contains("root = "), "report.Contains('root = ')");
+        }
+
+        private static async Task<string> DoWork()
+        {
+            ProfilingSession.Start("DoWork");
+            ITimingSession timingSession = ProfilingSession.Current.Profiler.GetTimingSession();
+            using (ProfilingSession.Current.Step("child1"))
+            {
+                await Task.WhenAll(Task.Run(() =>
+                    {
+                        using (ProfilingSession.Current.Step("child1.1"))
+                        {
+                            Thread.Sleep(10);
+                        }
+                    }),
+                    Task.Run(() =>
+                    {
+                        using (ProfilingSession.Current.Step("child1.2"))
+                        {
+                            Thread.Sleep(20);
+                        }
+                    }));
+            }
+            ProfilingSession.Stop();
+            string report = GetReport(timingSession);
+            return report;
+        }
+
+        private static string GetReport(ITimingSession timingSession)
+        {
+            long totalMs = timingSession.DurationMilliseconds;
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Profiling session: [{timingSession.Name}], {totalMs} ms total)");
+
+            IEnumerable<ITiming> timingsParentFirst = TraverseTimingsPreOrder(timingSession,
+                timingSession.Timings.ToList());
+
+            foreach (ITiming timing in timingsParentFirst)
+            {
+                int depth = GetDepth(timing);
+                var depthString = new string('>', depth);
+                sb.AppendLine($"{depthString} {timing.Name} = {timing.DurationMilliseconds} ms");
+            }
+            sb.AppendLine();
+            string report = sb.ToString();
+            return report;
+        }
+
+
+        private static IList<ITiming> TraverseTimingsPreOrder(ITiming parent,
+            IEnumerable<ITiming> allTimings,
+            int depth = 0)
+        {
+            SetDepth(parent, depth);
+            IEnumerable<ITiming> timings = allTimings as IList<ITiming> ?? allTimings.ToList();
+
+            return new[] {parent}.Concat(timings.Where(x => x.ParentId == parent.Id)
+                .SelectMany(child => TraverseTimingsPreOrder(child, timings, depth + 1))).ToList();
+        }
+
+        private static void SetDepth(ITiming timing, int depth)
+        {
+            if (timing.Data == null)
+                timing.Data = new Dictionary<string, string>();
+            timing.Data["depth"] = depth.ToString();
+        }
+
+        private static int GetDepth(ITiming timing)
+        {
+            return int.Parse(timing.Data["depth"]);
+        }
+
+        private class NanoProfilerStorageInMemory : IProfilingStorage
+        {
+            private readonly Action<ITimingSession> _onReport;
+
+            public NanoProfilerStorageInMemory(Action<ITimingSession> onReport)
+            {
+                _onReport = onReport;
+            }
+
+            public void SaveSession(ITimingSession session)
+            {
+                _onReport?.Invoke(session);
+            }
+        }
+    }
+}

--- a/src/Tests/NanoProfiler.Tests/NanoProfiler.Tests.csproj
+++ b/src/Tests/NanoProfiler.Tests/NanoProfiler.Tests.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CircularBufferTest.cs" />
+    <Compile Include="ConcurrencyTest.cs" />
     <Compile Include="Data\DbProfilerTest.cs" />
     <Compile Include="Data\DbTimingTest.cs" />
     <Compile Include="Data\ProfiledDbCommandTest.cs" />

--- a/src/Tests/NanoProfiler.Tests/NanoProfiler.Tests.csproj
+++ b/src/Tests/NanoProfiler.Tests/NanoProfiler.Tests.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EF.Diagnostics.Profiling.Tests</RootNamespace>
     <AssemblyName>NanoProfiler.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Hi, I am trying to use nanoprofiler to automatically generate profiling reports for Start/Stop pairs in highly concurrent situations, so if two threads or tasks do call the same `DoWork()` method that has a Start/Stop scope, then I would like two reports - one for each logical call context.
I am having trouble with arbitrarily losing reports, so I have written a repro test case to highlight this. 

Could you help me figure out why this happens? Hopefully I have misunderstood or misimplemented something.

This PR adds a few tests that arbitrarily break, due to the number of generated reports being lower than the number of call contexts.
