### PR TITLE
ConcurrencyTest: Fix tests by holding ref to ProfilingSession

### DIFF
--- a/src/Tests/NanoProfiler.Tests/ConcurrencyTest.cs
+++ b/src/Tests/NanoProfiler.Tests/ConcurrencyTest.cs
@@ -93,6 +93,10 @@ namespace EF.Diagnostics.Profiling.Tests
         private static async Task<string> DoWork()
         {
             ProfilingSession.Start("DoWork");
+
+            // Avoid GC of session
+            var profilingSession = ProfilingSession.Current;
+
             ITimingSession timingSession = ProfilingSession.Current.Profiler.GetTimingSession();
             using (ProfilingSession.Current.Step("child1"))
             {


### PR DESCRIPTION
Ref #4: fixes the problem of arbitrarily failing tests, due to GC of `ProfilingSession` in each call to `DoWork()`.