### PR TITLE
1. NanoProfilerModule: fix Request.Headers.AllKey.Contains() check is…

### DIFF
--- a/src/NanoProfiler.Web.Import/Handlers/NanoProfilerImportModule.cs
+++ b/src/NanoProfiler.Web.Import/Handlers/NanoProfilerImportModule.cs
@@ -105,12 +105,9 @@ namespace EF.Diagnostics.Profiling.Web.Import.Handlers
                     context.Response.ContentType = "application/json";
                     var result = ProfilingSession.CircularBuffer.FirstOrDefault(
                             r => r.Data != null && r.Data.ContainsKey(CorrelationId) && r.Data[CorrelationId] == exportCorrelationId);
-                    if (result != null)
-                    {
-                        context.Response.Write(ImportSerializer.SerializeSessions(new[] { result }));
-                        context.Response.End();
-                        return;
-                    }
+                    context.Response.Write(result != null ? ImportSerializer.SerializeSessions(new[] {result}) : "[]");
+                    context.Response.End();
+                    return;
                 }
             }
             else if (TryToImportDrillDownResult && path.IndexOf(ViewUrl, StringComparison.OrdinalIgnoreCase) >= 0)

--- a/src/NanoProfiler.Web/Handlers/NanoProfilerModule.cs
+++ b/src/NanoProfiler.Web/Handlers/NanoProfilerModule.cs
@@ -100,7 +100,7 @@ namespace EF.Diagnostics.Profiling.Web.Handlers
 
         private string GetCorrelationIdFromHeaders(HttpContext context)
         {
-            if (context.Request.Headers.AllKeys.Contains(ETCorrelationId))
+            if (context.Request.Headers.AllKeys.Contains(ETCorrelationId, StringComparer.OrdinalIgnoreCase))
             {
                 var correlationIds = context.Request.Headers.GetValues(ETCorrelationId);
                 if (correlationIds != null)


### PR DESCRIPTION
…sue for MONO behind fastcgi;

2. NanoProfilerImportModule: fix invalid response when querying by correlationId;